### PR TITLE
[fix] packge.json repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,7 @@
   "scripts": {
     "test": "mocha test/*.test.js"
   },
-  "repository": {
-    "type": "git",
-    "url": "http://github/3rd-Eden/githulk"
-  },
+  "repository": "githulks/githulk",
   "keywords": [
     "github",
     "api"


### PR DESCRIPTION
The previous value (http://github/3rd-Eden/githulk) is missing the .com and
therefore does not point at the repo.