### PR TITLE
[api] Add API for requesting reviewers on a PR

### DIFF
--- a/endpoints/pulls.js
+++ b/endpoints/pulls.js
@@ -51,7 +51,7 @@ Pulls.create = [
 Pulls.requestReviewers = [
   'reviewers',  // An array of reviewer users to request review from
   'team_reviewers' // An array of team slugs to request review from
-]
+];
 
 /**
  * List pull requests.
@@ -248,16 +248,16 @@ Pulls.prototype.merge = function merge(args) {
  */
 Pulls.prototype.requestReviewers = function requestReviewers(args) {
   args = this.api.args(arguments);
-  
-    var project = this.api.project(args.str)
-      , options = args.options || {};
-  
-    return this.send(
-      ['repos', project.user, project.repo, 'pulls', args.number, 'requested_reviewers'],
-      this.api.options(this.api.merge(options, { method: 'POST' }), Pulls.requestReviewers),
-      args.fn
-    );
-}
+
+  var project = this.api.project(args.str)
+    , options = args.options || {};
+
+  return this.send(
+    ['repos', project.user, project.repo, 'pulls', args.number, 'requested_reviewers'],
+    this.api.options(this.api.merge(options, { method: 'POST' }), Pulls.requestReviewers),
+    args.fn
+  );
+};
 
 //
 // Expose the issues API.

--- a/endpoints/pulls.js
+++ b/endpoints/pulls.js
@@ -43,6 +43,17 @@ Pulls.create = [
 ];
 
 /**
+ * All available options for requesting pull request review.
+ * 
+ * @type {Array}
+ * @private
+ */
+Pulls.requestReviewers = [
+  'reviewers',  // An array of reviewer users to request review from
+  'team_reviewers' // An array of team slugs to request review from
+]
+
+/**
  * List pull requests.
  *
  * @param {Object} options Optional options.
@@ -230,6 +241,7 @@ Pulls.prototype.merge = function merge(args) {
  * @param {Number} number The pull request number.
  * @param {Object} options Optional options.
  * @param {String[]} options.reviewers List of usernames to request review from
+ * @param {String[]} options.team_reviewers List of team slugs to request review from
  * @param {Function} fn The callback.
  * @returns {Assign}
  * @api public
@@ -242,7 +254,7 @@ Pulls.prototype.requestReviewers = function requestReviewers(args) {
   
     return this.send(
       ['repos', project.user, project.repo, 'pulls', args.number, 'requested_reviewers'],
-      this.api.options(this.api.merge(options, { method: 'POST' })),
+      this.api.options(this.api.merge(options, { method: 'POST' }), Pulls.requestReviewers),
       args.fn
     );
 }

--- a/endpoints/pulls.js
+++ b/endpoints/pulls.js
@@ -223,6 +223,30 @@ Pulls.prototype.merge = function merge(args) {
   );
 };
 
+/**
+ * Request review from the specified set of users on the given pull request.
+ *
+ * @param {String} project User/repo combination.
+ * @param {Number} number The pull request number.
+ * @param {Object} options Optional options.
+ * @param {String[]} options.reviewers List of usernames to request review from
+ * @param {Function} fn The callback.
+ * @returns {Assign}
+ * @api public
+ */
+Pulls.prototype.requestReviewers = function requestReviewers(args) {
+  args = this.api.args(arguments);
+  
+    var project = this.api.project(args.str)
+      , options = args.options || {};
+  
+    return this.send(
+      ['repos', project.user, project.repo, 'pulls', args.number, 'requested_reviewers'],
+      this.api.options(this.api.merge(options, { method: 'POST' })),
+      args.fn
+    );
+}
+
 //
 // Expose the issues API.
 //


### PR DESCRIPTION
Note that you'll need to pass a special `Accept` header to use parts of this API, depending on what GitHub version you're hitting:

For public GitHub (as of mid-October 2017), to use the `team_reviewers` field, you'll need to call this API with `Accept: application/vnd.github.thor-preview+json`

For GitHub Enterprise 2.9, you'll need to call this API with `Accept: application/vnd.github.black-cat-preview+json`

Here is how to send those headers:

```js
githulk.pulls.requestReviewers(project, prNumber, {
  headers: {
    Accept: <HEADER HERE>
  },
  reviewers: [
    'reviewerLogin'
  ]
}, done);
```